### PR TITLE
Fix lint issues for Vercel build

### DIFF
--- a/app/components/forms/AddInjectForm.tsx
+++ b/app/components/forms/AddInjectForm.tsx
@@ -37,7 +37,7 @@ const AddInjectForm = React.memo<AddInjectFormProps>(({ onAddInject, onImportCli
       setNotes('')
       setResources('')
     }
-  }, [title, dueTime, type, to, from, onAddInject])
+  }, [title, dueTime, type, to, from, notes, resources, onAddInject])
 
   return (
     <div className="bg-gray-800 rounded-lg p-6">

--- a/app/components/timeline/Timeline.tsx
+++ b/app/components/timeline/Timeline.tsx
@@ -235,11 +235,11 @@ const Timeline: React.FC<TimelineProps> = ({
                         <div><span className="text-yellow-400">To:</span> {inject.to || 'All units'}</div>
                         <div><span className="text-yellow-400">From:</span> {inject.from || 'Exercise Control'}</div>
                         <div><span className="text-yellow-400">Status:</span> <span className="capitalize">{inject.status}</span></div>
-                        {('notes' in inject) && (inject as any).notes ? (
-                          <div><span className="text-yellow-400">Notes:</span> {(inject as any).notes}</div>
+                        {inject.notes ? (
+                          <div><span className="text-yellow-400">Notes:</span> {inject.notes}</div>
                         ) : null}
-                        {('resources' in inject) && (inject as any).resources ? (
-                          <div><span className="text-yellow-400">Resources:</span> {(inject as any).resources}</div>
+                        {inject.resources ? (
+                          <div><span className="text-yellow-400">Resources:</span> {inject.resources}</div>
                         ) : null}
                       </div>
                       {/* Tooltip arrow */}


### PR DESCRIPTION
## Summary
- include missing dependencies in the add-inject form submit handler
- replace `any` usages in the timeline tooltip and dashboard activity tracking with typed helpers
- add Mammoth loader typings so Next.js linting passes for import/export utilities

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca3de1806483298638823acc97f7af